### PR TITLE
Make tree values iterable without requiring search for empty key.

### DIFF
--- a/code/src/main/java/com/googlecode/concurrenttrees/radix/RadixTree.java
+++ b/code/src/main/java/com/googlecode/concurrenttrees/radix/RadixTree.java
@@ -28,7 +28,7 @@ import com.googlecode.concurrenttrees.common.KeyValuePair;
  *
  * @author Niall Gallagher
  */
-public interface RadixTree<O> {
+public interface RadixTree<O> extends Iterable<KeyValuePair<O>> {
 
     /**
      * Associates the given value with the given key; replacing any previous value associated with the key.

--- a/code/src/main/java/com/googlecode/concurrenttrees/radixinverted/ConcurrentInvertedRadixTree.java
+++ b/code/src/main/java/com/googlecode/concurrenttrees/radixinverted/ConcurrentInvertedRadixTree.java
@@ -458,9 +458,12 @@ public class ConcurrentInvertedRadixTree<O> implements InvertedRadixTree<O>, Pre
     }
 
     @Override
+    public Iterator<KeyValuePair<O>> iterator() {
+        return radixTree.iterator();
+    }
+
+    @Override
     public Node getNode() {
         return radixTree.getNode();
     }
-
-
 }

--- a/code/src/main/java/com/googlecode/concurrenttrees/radixreversed/ReversedRadixTree.java
+++ b/code/src/main/java/com/googlecode/concurrenttrees/radixreversed/ReversedRadixTree.java
@@ -34,7 +34,7 @@ import com.googlecode.concurrenttrees.common.KeyValuePair;
  * @see com.googlecode.concurrenttrees.radix.RadixTree
  * @author Niall Gallagher
  */
-public interface ReversedRadixTree<O> {
+public interface ReversedRadixTree<O> extends Iterable<KeyValuePair<O>> {
 
     /**
      * Associates the given value with the given key; replacing any previous value associated with the key.

--- a/code/src/main/java/com/googlecode/concurrenttrees/suffix/SuffixTree.java
+++ b/code/src/main/java/com/googlecode/concurrenttrees/suffix/SuffixTree.java
@@ -28,7 +28,7 @@ import com.googlecode.concurrenttrees.common.KeyValuePair;
  *
  * @author Niall Gallagher
  */
-public interface SuffixTree<O> {
+public interface SuffixTree<O> extends Iterable<KeyValuePair<O>> {
 
     /**
      * Associates the given value with the given key; replacing any previous value associated with the key.

--- a/code/src/test/java/com/googlecode/concurrenttrees/radix/ConcurrentRadixTreeTest.java
+++ b/code/src/test/java/com/googlecode/concurrenttrees/radix/ConcurrentRadixTreeTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 import java.io.*;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 
 import static org.junit.Assert.*;
@@ -961,6 +962,29 @@ public class ConcurrentRadixTreeTest {
         // Testing the various (unlikely) ways to fall through classification to have the exception thrown...
         Node dummyNodeFound = getNodeFactory().createNode("DUMMY", 1, Collections.<Node>emptyList(), false);
             new ConcurrentRadixTree.SearchResult("DUMMY", dummyNodeFound, 4, 70, null, null);
+    }
+
+    @Test
+    public void testIteration() {
+        ConcurrentRadixTree<Integer> tree = new ConcurrentRadixTree<Integer>(getNodeFactory());
+        tree.put("TEST", 1);
+        tree.put("TEAM", 2);
+        tree.put("TOAST", 3);
+
+        Iterator<KeyValuePair<Integer>> it = tree.iterator();
+        assertTrue(it.hasNext());
+        KeyValuePair<Integer> team = it.next();
+        assertEquals("TEAM", team.getKey());
+        assertEquals(2, (Object) team.getValue());
+        assertTrue(it.hasNext());
+        KeyValuePair<Integer> test = it.next();
+        assertEquals("TEST", test.getKey());
+        assertEquals(1, (Object) test.getValue());
+        assertTrue(it.hasNext());
+        KeyValuePair<Integer> toast = it.next();
+        assertEquals("TOAST", toast.getKey());
+        assertEquals(3, (Object) toast.getValue());
+        assertFalse(it.hasNext());
     }
 
     @Test

--- a/code/src/test/java/com/googlecode/concurrenttrees/radixinverted/ConcurrentInvertedRadixTreeTest.java
+++ b/code/src/test/java/com/googlecode/concurrenttrees/radixinverted/ConcurrentInvertedRadixTreeTest.java
@@ -16,11 +16,14 @@
 package com.googlecode.concurrenttrees.radixinverted;
 
 import com.googlecode.concurrenttrees.common.Iterables;
+import com.googlecode.concurrenttrees.common.KeyValuePair;
 import com.googlecode.concurrenttrees.common.PrettyPrinter;
 import com.googlecode.concurrenttrees.radix.node.NodeFactory;
 import com.googlecode.concurrenttrees.radix.node.concrete.DefaultCharArrayNodeFactory;
 import com.googlecode.concurrenttrees.testutil.TestUtility;
 import org.junit.Test;
+
+import java.util.Iterator;
 
 import static org.junit.Assert.*;
 import static org.junit.Assert.assertEquals;
@@ -438,6 +441,29 @@ public class ConcurrentInvertedRadixTreeTest {
         assertEquals("[FOO, FOOD]", Iterables.toString(tree.getClosestKeys("FOB")));
         assertEquals("[2, 1]", Iterables.toString(tree.getValuesForClosestKeys("FOB")));
         assertEquals("[(FOO, 2), (FOOD, 1)]", Iterables.toString(tree.getKeyValuePairsForClosestKeys("FOB")));
+    }
+
+    @Test
+    public void testIteration() {
+        ConcurrentInvertedRadixTree<Integer> tree = new ConcurrentInvertedRadixTree<Integer>(getNodeFactory());
+        tree.put("TEST", 1);
+        tree.put("TEAM", 2);
+        tree.put("TOAST", 3);
+
+        Iterator<KeyValuePair<Integer>> it = tree.iterator();
+        assertTrue(it.hasNext());
+        KeyValuePair<Integer> team = it.next();
+        assertEquals("TEAM", team.getKey());
+        assertEquals(2, (Object) team.getValue());
+        assertTrue(it.hasNext());
+        KeyValuePair<Integer> test = it.next();
+        assertEquals("TEST", test.getKey());
+        assertEquals(1, (Object) test.getValue());
+        assertTrue(it.hasNext());
+        KeyValuePair<Integer> toast = it.next();
+        assertEquals("TOAST", toast.getKey());
+        assertEquals(3, (Object) toast.getValue());
+        assertFalse(it.hasNext());
     }
 
     @Test

--- a/code/src/test/java/com/googlecode/concurrenttrees/radixreversed/ConcurrentReversedRadixTreeTest.java
+++ b/code/src/test/java/com/googlecode/concurrenttrees/radixreversed/ConcurrentReversedRadixTreeTest.java
@@ -16,11 +16,14 @@
 package com.googlecode.concurrenttrees.radixreversed;
 
 import com.googlecode.concurrenttrees.common.Iterables;
+import com.googlecode.concurrenttrees.common.KeyValuePair;
 import com.googlecode.concurrenttrees.common.PrettyPrinter;
 import com.googlecode.concurrenttrees.radix.node.NodeFactory;
 import com.googlecode.concurrenttrees.radix.node.concrete.DefaultCharArrayNodeFactory;
 import com.googlecode.concurrenttrees.testutil.TestUtility;
 import org.junit.Test;
+
+import java.util.Iterator;
 
 import static org.junit.Assert.*;
 
@@ -165,6 +168,29 @@ public class ConcurrentReversedRadixTreeTest {
                 "└── ○ TSAOT (3)\n";
         actual = PrettyPrinter.prettyPrint(tree);
         assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testIteration() {
+        ConcurrentReversedRadixTree<Integer> tree = new ConcurrentReversedRadixTree<Integer>(getNodeFactory());
+        tree.put("TEST", 1);
+        tree.put("TEAM", 2);
+        tree.put("TOAST", 3);
+
+        Iterator<KeyValuePair<Integer>> it = tree.iterator();
+        assertTrue(it.hasNext());
+        KeyValuePair<Integer> team = it.next();
+        assertEquals("TEAM", team.getKey());
+        assertEquals(2, (Object) team.getValue());
+        assertTrue(it.hasNext());
+        KeyValuePair<Integer> toast = it.next();
+        assertEquals("TOAST", toast.getKey());
+        assertEquals(3, (Object) toast.getValue());
+        assertTrue(it.hasNext());
+        KeyValuePair<Integer> test = it.next();
+        assertEquals("TEST", test.getKey());
+        assertEquals(1, (Object) test.getValue());
+        assertFalse(it.hasNext());
     }
 
     @Test

--- a/code/src/test/java/com/googlecode/concurrenttrees/suffix/ConcurrentSuffixTreeTest.java
+++ b/code/src/test/java/com/googlecode/concurrenttrees/suffix/ConcurrentSuffixTreeTest.java
@@ -16,6 +16,7 @@
 package com.googlecode.concurrenttrees.suffix;
 
 import com.googlecode.concurrenttrees.common.Iterables;
+import com.googlecode.concurrenttrees.common.KeyValuePair;
 import com.googlecode.concurrenttrees.common.PrettyPrinter;
 import com.googlecode.concurrenttrees.radix.node.NodeFactory;
 import com.googlecode.concurrenttrees.radix.node.concrete.DefaultCharArrayNodeFactory;
@@ -455,6 +456,29 @@ public class ConcurrentSuffixTreeTest {
                 return new LinkedHashSet<String>();
             }
         };
+    }
+
+    @Test
+    public void testIteration() {
+        ConcurrentSuffixTree<Integer> tree = new ConcurrentSuffixTreeTestImpl<Integer>(getNodeFactory());
+        tree.put("TEST", 1);
+        tree.put("TEAM", 2);
+        tree.put("TOAST", 3);
+
+        Iterator<KeyValuePair<Integer>> it = tree.iterator();
+        assertTrue(it.hasNext());
+        KeyValuePair<Integer> team = it.next();
+        assertEquals("TEAM", team.getKey());
+        assertEquals(2, (Object) team.getValue());
+        assertTrue(it.hasNext());
+        KeyValuePair<Integer> toast = it.next();
+        assertEquals("TOAST", toast.getKey());
+        assertEquals(3, (Object) toast.getValue());
+        assertTrue(it.hasNext());
+        KeyValuePair<Integer> test = it.next();
+        assertEquals("TEST", test.getKey());
+        assertEquals(1, (Object) test.getValue());
+        assertFalse(it.hasNext());
     }
 
     @Test


### PR DESCRIPTION
I am not sure if you wanted to add this, but with these changes all trees become iterable over their values. This can be rather convenient, especially with newer Java versions where tree contents are stream processed.

You can already achieve this by searching for an empty string as a key, but I felt like this would make using code more readable with a minor performance benefit. Please consider this as a suggestion, I fully understand if you did not want to add this, too. Thanks!